### PR TITLE
Add yamllint with pre-commit #367

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,11 @@ repos:
         name: run markdown link check
         description: check the Markdown files for broken links
         args: [-q]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        name: run yamllint
+        description: Check YAML files with yamllint
+        args: [--config-file=.yamllint.yml]
+        types: [yaml]

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,37 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']
+    check-keys: true
+
+  comments-indentation: disable
+
+  empty-lines:
+    max: 2
+    max-start: 1
+    max-end: 1
+
+  indentation:
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+ignore: |
+  node_modules/
+  .next/
+  dist/
+  build/
+  archive/


### PR DESCRIPTION
Adds yamllint to pre-commit hooks for consistent YAML formatting.

Closes #367

## Changes
- Added `.yamllint.yml` config with 120 char line limit
- Updated `.pre-commit-config.yaml` to include yamllint hook
- Configured to work with GitHub Actions (allows `true/false`, `on/off` values)
- Ignores build dirs (`node_modules`, `.next`, etc.)

All existing YAML files pass the new linting rules.