### PR TITLE
ci: add markdown-link-check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,10 @@ repos:
         args: [--config=.github/linters/.markdown-lint.yml]
         types: [markdown]
         files: \.md$
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.14.0
+    hooks:
+      - id: markdown-link-check
+        name: run markdown-link-check
+        description: Check Markdown files for broken links
+        args: [--quiet]


### PR DESCRIPTION
## Description
Add `markdown-link-check` to the pre-commit configuration to automatically validate markdown links in the repository.

## Changes Made
- Added `markdown-link-check` hook to `.pre-commit-config.yaml`
- Uses the official tcort/markdown-link-check repository (v3.14.0)
- Configured with `--quiet` argument to reduce noise in CI output

## Benefits
- Automatically catches broken links in markdown files before commit
- Prevents documentation from having dead links
- Improves overall documentation quality and user experience

## Testing
The pre-commit hook will run automatically when markdown files are staged for commit.

Resolves #371