### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: 🌐 Salam Website
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SalamLang/Salam-Website/security/code-scanning/3](https://github.com/SalamLang/Salam-Website/security/code-scanning/3)

The best way to address this problem is to add an explicit `permissions` block to your workflow. Since the workflow checks out code and deploys via SSH but does not push code, create releases, or interact with issues/pull requests, it likely only needs read access to repository contents. 

You should add:
```yaml
permissions:
  contents: read
```
immediately after the workflow `name:` at the top, so it applies as the default for all jobs in the workflow. No further YAML structure or indentation changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
